### PR TITLE
Drop start-new-session after first time connection

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -1917,6 +1917,9 @@ XpraClient.prototype._process_hello = function(packet, ctx) {
 		return true;
 	}, ctx.PING_FREQUENCY);
 	ctx.reconnect_attempt = 0;
+        // Drop start_new_session to avoid creating new displays
+        // on reconnect
+	ctx.start_new_session = null;
 	ctx.on_connection_progress("Session started", "", 100);
 	ctx.on_connect();
 	ctx.connected = true;


### PR DESCRIPTION
Fixes the logic flaw spawning new and new displays on reconnection
if "start" / "start-desktop" is invoked.
