### PR TITLE
Do not emit connection-lost immediately after successful reconnect

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -994,7 +994,7 @@ XpraClient.prototype._check_echo_timeout = function(ping_time) {
 	if (this.reconnect_in_progress) {
 		return;
 	}
-	if(this.last_ping_echoed_time < ping_time) {
+	if(this.last_ping_echoed_time > 0 && this.last_ping_echoed_time < ping_time) {
 		if (this.reconnect && this.reconnect_attempt<this.reconnect_count) {
 			this.warn("ping timeout - reconnecting");
 			this.reconnect_attempt++;


### PR DESCRIPTION
Fixes second/third/fourth attempt to reconnect caused by zero as last_echo_ping.
