### PR TITLE
Implement override of client screen width

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -24,6 +24,7 @@ Default values can be specified in the [default-settings.txt](../html5/default-s
 |`steal`       |Take over the session and disconnect any existing client(s)|Yes|
 |`reconnect`   |Automatically reconnect when the connection drops|Yes|
 |`bandwidth_limit` |Bandwidth budget in bits per second|`0` (no limit)|
+|`override_width`|The desired width of client desktop, pixels|width of browser window|
 
 `*1` the default values for the server host, port and SSL status will mirror that of the connection
 which was used to load the HTMl5 client (as found in the browser's URL bar), and those values don't usually need to be modified.

--- a/html5/connect.html
+++ b/html5/connect.html
@@ -17,6 +17,8 @@
 	<!-- Custom styles for this template -->
 	<link href="css/signin.css" rel="stylesheet">
 	<title>Xpra HTML5 Client</title>
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="mobile-web-app-capable" content="yes">
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 	<link rel="icon" type="image/png" href="favicon.png">
 
@@ -289,6 +291,10 @@
 					<input title="path" type="text" class="form-control" id="path" placeholder="" size="16" maxlength="256">
 				  </li>
 				  <li class="list-group-item">
+					<span>Client Screen Width:</span>
+					<input title="override_width" type="text" class="form-control" id="override_width" size="16" maxlength="256">
+				  </li>
+				  <li class="list-group-item">
 				  	<span>Debugging</span>:<br/>
 				  	<input type="checkbox" id="debug_main"> <span>Main</span>,
 				  	<input type="checkbox" id="debug_keyboard"> <span>keyboard</span>,
@@ -315,7 +321,7 @@
 
 const VALUE_PROPERTIES = ["server", "port", "path", "username", "password", "key",
 					"bandwidth_limit", "encoding", "keyboard_layout", "audio_codec", "toolbar_position",
-					"display", "shadow_display",
+					"display", "shadow_display", "override_width",
 					];
 const BOOLEAN_PROPERTIES = ["keyboard", "clipboard", "printing", "file_transfer",
 		"sound", "ignore_audio_blacklist",
@@ -530,6 +536,8 @@ function fill_form(default_settings) {
 	document.getElementById("port").value = getparam("port") || link.port || protocol_port;
 	document.getElementById("path").value = path || pathname;
 	document.getElementById("username").value = getparam("username") || "";
+	document.getElementById("override_width").placeholder = getparam("override_width") || window.innerWidth;
+
 
 	const ssl = getboolparam("ssl", https);
 	const insecure = getboolparam("insecure", false);

--- a/html5/index.html
+++ b/html5/index.html
@@ -11,9 +11,12 @@
 		<title>xpra websockets client</title>
 		<meta charset="utf-8">
 		<meta name="description" content="xpra websockets client">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="mobile-web-app-capable" content="yes">
 		<link rel="shortcut icon" type="image/png" href="./favicon.png" id="favicon">
 
 		<link rel="stylesheet" href="css/client.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="css/spinner.css">
 
 		<script type="text/javascript" src="js/lib/es6-shim.js"></script>
@@ -246,6 +249,22 @@
 				}
 				try {
 					v = parseInt(v)
+				}
+				catch(e) {
+					return default_value;
+				}
+				if (v===null || isNaN(v)) {
+					return default_value;
+				}
+				return v;
+			}
+			const getfloatparam = function(prop, default_value) {
+				let v = Utilities.getparam(prop);
+				if (v==null && prop in default_settings) {
+					v = default_settings[prop];
+				}
+				try {
+					v = parseFloat(v)
 				}
 				catch(e) {
 					return default_value;
@@ -509,6 +528,7 @@
 				const floating_menu = getboolparam("floating_menu", true);
 				const toolbar_position = getparam("toolbar_position");
 				const autohide = getboolparam("autohide", false);
+				const override_width = getfloatparam("override_width", window.innerWidth);
 				vrefresh = getintparam("vrefresh", -1);
 				if (vrefresh<0 && fps>=30) {
 					vrefresh = fps;
@@ -519,6 +539,13 @@
 				}
 				catch (e) {
 					//ignore
+				}
+
+				if (window.innerWidth!==override_width) {
+					document.querySelector("meta[name=viewport]").setAttribute('content',
+						'width=device-width, initial-scale='+
+						(window.innerWidth/override_width)+
+						', maximum-scale=1.0, user-scalable=0');
 				}
 
 				let progress_timer;


### PR DESCRIPTION
Summary of changes:

﻿  * Add and document `override_width` in pixels
  * Adjust viewport scaling if width is overridden
  * Add meta tags for fullscreen operation on iOS and
    Android when user adds the Xpra HTML5 client webpage
    to home screen.
