### PR TITLE
Close client if user confirmed server shutdown

### DIFF
--- a/html5/index.html
+++ b/html5/index.html
@@ -309,6 +309,7 @@
 
 			function confirm_shutdown_server() {
 				if (confirm("Shutdown this server?")) {
+					client.reconnect = false;
 					client.send(["shutdown-server"]);
 				}
 			}


### PR DESCRIPTION
Fixes reconnects triggered by 'connection-lost' after user
requested the remote Xpra server to shut down.
