### PR TITLE
Fix broken language-to-keymap matcher

### DIFF
--- a/html5/js/Keycodes.js
+++ b/html5/js/Keycodes.js
@@ -1638,7 +1638,7 @@ KEYSYM_TO_LAYOUT = {
 	"Farsi"		: "ir",
 	"Arabic"	: "ar",
 	"Cyrillic"	: "ru",
-	"Ukrainian"	: "uk",
+	"Ukrainian"	: "ua",
 	"Macedonia"	: "mk",
 	"Greek"		: "gr",
 	"hebrew"	: "he",

--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -196,7 +196,7 @@ const Utilities = {
 			}
 			//ie: "en"
 			layout = l[0].toLowerCase();
-			const tmp = LANGUAGE_TO_LAYOUT[v];
+			const tmp = LANGUAGE_TO_LAYOUT[layout];
 			if (tmp) {
 				layout = tmp;
 			}


### PR DESCRIPTION
Also fix Ukrainian X11 layput name override, so browser-supplied
language 'uk' is consistently mapped to X11's 'ua' layout, making
xkbcomp happy.
