### PR TITLE
Make window corners round

### DIFF
--- a/html5/css/client.css
+++ b/html5/css/client.css
@@ -13,7 +13,7 @@ html, body {
 
 div.window canvas {
 	touch-action: none;
-	border-radius: 0 0 2px 2px;
+	border-radius: 0 0 3px 3px;
 }
 
 body.desktop {
@@ -98,7 +98,7 @@ canvas {
 	border-width : 1px;
 	border-style : solid;
 	box-shadow : 0px 10px 25px rgba(0, 0, 0, 0.5);
-	border-radius: 6px 6px 2px 2px;
+	border-radius: 6px 6px 3px 3px;
 }
 
 .windowicon {

--- a/html5/css/client.css
+++ b/html5/css/client.css
@@ -13,6 +13,7 @@ html, body {
 
 div.window canvas {
 	touch-action: none;
+	border-radius: 0 0 2px 2px;
 }
 
 body.desktop {
@@ -97,6 +98,7 @@ canvas {
 	border-width : 1px;
 	border-style : solid;
 	box-shadow : 0px 10px 25px rgba(0, 0, 0, 0.5);
+	border-radius: 6px 6px 2px 2px;
 }
 
 .windowicon {


### PR DESCRIPTION
This is the current looking of a window with Xpra-html client:
<img width="646" alt="Screen Shot 2021-08-01 at 11 28 38 AM" src="https://user-images.githubusercontent.com/478667/127766461-ae16de58-ca33-48f6-b9e9-60db1f0c1377.png">

Most desktop environment nowadays uses round corners, for example:

MacOS
<img width="647" alt="Screen Shot 2021-08-01 at 11 28 12 AM" src="https://user-images.githubusercontent.com/478667/127766472-f8d85e87-5ba4-4af0-8534-3bcad8e6ded9.png">

Linux XFCE
<img width="664" alt="Screen Shot 2021-08-01 at 11 27 57 AM" src="https://user-images.githubusercontent.com/478667/127766481-b7e64fb7-46c8-4d8e-89a5-aa06e2b106b6.png">


This PR will make the window looks like this:

<img width="655" alt="Screen Shot 2021-08-01 at 11 47 17 AM" src="https://user-images.githubusercontent.com/478667/127766645-d457fa3b-b6e9-46b1-896c-3228c6e0deb7.png">
