### PR TITLE
return Uint8Array if no re-striding is needed

### DIFF
--- a/html5/js/DecodeWorker.js
+++ b/html5/js/DecodeWorker.js
@@ -36,7 +36,7 @@ function decode_rgb(packet) {
 	}
 	//coding=rgb32
 	if (target_stride==rowstride) {
-		return data;
+		return new Uint8Array(data);
 	}
 	//re-striding
 	//might be quicker to copy 32bit at a time using Uint32Array


### PR DESCRIPTION
decode_rgb returns a ArrayBuffer instead of Uint8Array. This causes an error (ImageData byte length is not a multiple of 4 * width) on line 185 if no re-striding is done.