### PR TITLE
Fix clipboard-related event handlers

### DIFF
--- a/html5/index.html
+++ b/html5/index.html
@@ -1365,11 +1365,20 @@
 				});
 				// disable right click menu:
 				window.oncontextmenu = function(e) {
-					client._poll_clipboard(e);
+					if (this.clipboard_direction === "to-client" || this.clipboard_direction === "both") {
+						client._poll_clipboard(e);
+					}
 					e.preventDefault();
 					e.stopPropagation();
 					return false;
 				}
+
+				// Send clipboard from browser on focus if client-to-server clipboard is enabled.
+				$(window).on("focus", (e) => {
+					if (this.clipboard_direction === "to-server" || this.clipboard_direction === "both") {
+						client._poll_clipboard(e);
+					}
+				});
 			}
 
 			$(document).ready(function() {

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -140,6 +140,7 @@ XpraClient.prototype.init_state = function(container) {
 	this.scroll_reverse_x = false;
 	this.scroll_reverse_y = false;
 	// clipboard
+	this.clipboard_direction = default_settings["clipboard_direction"] || "both";
 	this.clipboard_datatype = null;
 	this.clipboard_buffer = "";
 	this.clipboard_server_buffers = {};
@@ -879,11 +880,8 @@ XpraClient.prototype.do_keyb_process = function(pressed, event) {
 		unpress_now = true;
 	}
 
-	//if (keyname=="Control_L" || keyname=="Control_R")
-	this._poll_clipboard(event);
-
 	let allow_default = false;
-	if (this.clipboard_enabled) {
+	if (this.clipboard_enabled && client.clipboard_direction !== "to-server") {
 		//allow some key events that need to be seen by the browser
 		//for handling the clipboard:
 		let clipboard_modifier_keys = ["Control_L", "Control_R", "Shift_L", "Shift_R"];
@@ -1459,7 +1457,7 @@ XpraClient.prototype.do_window_mouse_click = function(e, window, pressed) {
 		return;
 	}
 	let send_delay = 0;
-	if (this._poll_clipboard(e)) {
+	if (client.clipboard_direction !== "to-server" && this._poll_clipboard(e)) {
 		send_delay = CLIPBOARD_EVENT_DELAY;
 	}
 	const mouse = this.getMouse(e, window),


### PR DESCRIPTION
This fixes a bug where the clipboard was getting overwritten by server-side copies, even when `clipboard_direction=to-server`. This prevents server-side copies when `clipboard_direction=to-server`.

One must set `clipboard_direction` in `default_settings.txt` to use this fix.

Note: We don't need to send the clipboard on every keyboard event. Capturing the contents on focus should be sufficient, if the intent is to copy data from the client browser to the server.

Credit: @danisla 