### PR TITLE
Prevent stuck keys (by sending keyup on blur)

### DIFF
--- a/html5/index.html
+++ b/html5/index.html
@@ -1379,6 +1379,18 @@
 						client._poll_clipboard(e);
 					}
 				});
+
+				// Prevent stuck keys.
+				$(window).on("blur", (e) => {
+					if (client.last_key_packet.length > 2 && client.last_keycode_pressed > 0) {
+						console.log("clearing keycode: " + client.last_keycode_pressed);
+						key_packet = client.last_key_packet;
+						// Set pressed = false to indicate key up.
+						key_packet[3] = false;
+						client.send(key_packet);
+						client.last_key_packet = [];
+					}
+				});
 			}
 
 			$(document).ready(function() {

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -129,6 +129,7 @@ XpraClient.prototype.init_state = function(container) {
 	this.browser_language_change_embargo_time = 0;
 	this.key_layout = null;
 	this.last_keycode_pressed = 0;
+	this.last_key_packet = [];
 	// mouse
 	this.last_button_event = [-1, false, -1, -1];
 	this.mousedown_event = null;
@@ -933,7 +934,9 @@ XpraClient.prototype.do_keyb_process = function(pressed, event) {
 		const me = this;
 		setTimeout(function () {
 			while (me.key_packets.length>0) {
-				me.send(me.key_packets.shift());
+				var key_packet = me.key_packets.shift();
+				me.last_key_packet = key_packet;
+				me.send(key_packet);
 			}
 		}, delay);
 	}


### PR DESCRIPTION
This fixes a bug where, if the user defocused Xpra shortly after pressing a key (sending a keydown), that key could get stuck (the matching keyup would never be sent).