### PR TITLE
Replace `scroll_reverse_y` setting with auto-detection

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -60,7 +60,6 @@ By default the HTML5 client will refuse to send passwords over remote unencrypte
 |`file_transfer`|Enable file-transfers|Yes|
 |`swap_keys`   |Swap Command and Control keys|Yes on MacOS|
 |`scroll_reverse_x` |Reverse X axis of the mouse pointer|No|
-|`scroll_reverse_y` |Reverse Y axis of the mouse pointer|Yes on MacOS|
 |`floating_menu` |Show a floating menu|Yes|
 |`toolbar_position` |Default position of the toolbar (ie: `top`, `top-right`)|`top-left`|
 |`autohide`    |Hide most of the toolbar until the pointer hovers over it|No|

--- a/html5/connect.html
+++ b/html5/connect.html
@@ -278,7 +278,6 @@
 				  	<input type="checkbox" id="swap_keys"> <span>Swap command and control key</span>
 				  </li>
 				  <li class="list-group-item">
-				  	<input type="checkbox" id="scroll_reverse_y"> <span>Reverse vertical scrolling</span>
 				  	<input type="checkbox" id="scroll_reverse_x"> <span>Reverse horizontal scrolling</span>
 				  </li>
 				  <li class="list-group-item">
@@ -339,7 +338,7 @@ const BOOLEAN_PROPERTIES = ["keyboard", "clipboard", "printing", "file_transfer"
 		"sound", "ignore_audio_blacklist",
 		"exit_with_children", "exit_with_client",
 		"sharing", "steal", "reconnect", "swap_keys",
-		"scroll_reverse_x", "scroll_reverse_y",
+		"scroll_reverse_x",
 		"video", "mediasource_video",
 		"ssl", "insecure",
 		"floating_menu", "autohide", "clock",
@@ -1143,7 +1142,7 @@ function fill_form(default_settings) {
 		"exit_with_children", "exit_with_client",
 		"sharing", "steal", "reconnect", "swap_keys",
 		"video", "mediasource_video", "floating_menu", "autohide", "clock",
-		"scroll_reverse_x", "scroll_reverse_y",
+		"scroll_reverse_x",
 		"debug_main", "debug_keyboard", "debug_geometry", "debug_mouse", "debug_clipboard", "debug_draw", "debug_audio", "debug_network"];
 	const default_on = ["steal", "clipboard", "printing", "file_transfer", "reconnect", "floating_menu", "clock", "exit_with_children", "exit_with_client"];
 	//even on 64-bit, video decoding is too slow
@@ -1152,7 +1151,6 @@ function fill_form(default_settings) {
 	//}
 	if (Utilities.isMacOS()) {
 		default_on.push("swap_keys");
-		default_on.push("scroll_reverse_y");
 	}
 	if (Utilities.isMobile()) {
 		//show the on-screen keyboard by default on mobile:

--- a/html5/index.html
+++ b/html5/index.html
@@ -596,7 +596,6 @@
 				const reconnect = getboolparam("reconnect", true);
 				const swap_keys = getboolparam("swap_keys", Utilities.isMacOS());
 				const scroll_reverse_x = getboolparam("scroll_reverse_x", false);
-				const scroll_reverse_y = getboolparam("scroll_reverse_y", Utilities.isMacOS());
 				const floating_menu = getboolparam("floating_menu", true);
 				const toolbar_position = getparam("toolbar_position");
 				const autohide = getboolparam("autohide", false);
@@ -687,7 +686,6 @@
 				client.swap_keys = swap_keys;
 				client.on_connection_progress = connection_progress;
 				client.scroll_reverse_x = scroll_reverse_x;
-				client.scroll_reverse_y = scroll_reverse_y;
 				client.vrefresh = vrefresh;
 				client.scale = scale;
 				//example overrides:
@@ -833,7 +831,6 @@
 									"keyboard_layout"	: keyboard_layout,
 									"swap_keys"			: swap_keys,
 									"scroll_reverse_x"	: scroll_reverse_x,
-									"scroll_reverse_y"	: scroll_reverse_y,
 									"reconnect"			: reconnect,
 									"action"			: action,
 									"display"			: display,

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -138,7 +138,6 @@ XpraClient.prototype.init_state = function(container) {
 	this.wheel_delta_y = 0;
 	this.mouse_grabbed = false;
 	this.scroll_reverse_x = false;
-	this.scroll_reverse_y = false;
 	// clipboard
 	this.clipboard_datatype = null;
 	this.clipboard_buffer = "";
@@ -1503,6 +1502,25 @@ XpraClient.prototype.do_window_mouse_click = function(e, window, pressed) {
 	}, send_delay);
 };
 
+// Source: https://deepmikoto.com/coding/1--javascript-detect-mouse-wheel-direction
+XpraClient.prototype.detect_vertical_scroll_direction = function(e, window) {
+	var delta = null
+	var direction = false;
+	if ( !e ) { // if the event is not provided, we get it from the window object
+		e = window.event;
+	}
+	if ( e.wheelDelta ) { // will work in most cases
+		delta = e.wheelDelta / 60;
+	} else if ( e.detail ) { // fallback for Firefox
+		delta = -e.detail / 2;
+	}
+	if ( delta !== null ) {
+		direction = delta > 0 ? 'up' : 'down';
+	}
+
+	return direction;
+};
+
 XpraClient.prototype._window_mouse_scroll = function(ctx, e, window) {
 	ctx.do_window_mouse_scroll(e, window);
 };
@@ -1528,10 +1546,9 @@ XpraClient.prototype.do_window_mouse_scroll = function(e, window) {
 	if (this.scroll_reverse_x) {
 		px = -px;
 	}
-	if (this.scroll_reverse_y) {
+	if (this.detect_vertical_scroll_direction(e, window) === "up" && py > 0) {
 		py = -py;
 	}
-	
 	const apx = Math.abs(px);
 	const apy = Math.abs(py);
 	if (this.server_precise_wheel) {


### PR DESCRIPTION
The `scroll_reverse_y` setting incorrectly handled MacOS natural scrolling. This solution should properly detect vertical scrolling inversion at runtime.

See https://deepmikoto.com/coding/1--javascript-detect-mouse-wheel-direction for the auto-detection approach.