### PR TITLE
Add `root_window_click_fix` settings flag for the situational fix

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -153,6 +153,8 @@ XpraClient.prototype.init_state = function(container) {
 	else {
 		this.log("no clipboard write support: no images, navigator.clipboard=", navigator.clipboard);
 	}
+	// root window click fix
+	this.root_window_click_fix = (default_settings["root_window_click_fix"] || "false") == true;
 	// printing / file-transfer:
 	this.remote_printing = false;
 	this.remote_file_transfer = false;

--- a/html5/js/Window.js
+++ b/html5/js/Window.js
@@ -148,11 +148,16 @@ function XpraWindow(client, canvas_state, wid, x, y, w, h, metadata, override_re
 			jQuery(this.div).draggable({ transform: true });
 		}
 		jQuery(this.div).draggable({ cancel: "canvas" });
+		// Fake a click on the root window.
+		// This helps some buggy Java applications close their popup menus.
+		// However, this can also break the UX in other situations
+		// (ex: when dragging over other maximized windows, causing them to raise),
+		// so this is gated behind a settings flag.
 		function root_window_click(ev) {
-			//fake a click on the root window,
-			//this helps some buggy Java applications close their popup menus
-			client.do_window_mouse_click(ev, null, true);
-			client.do_window_mouse_click(ev, null, false);
+			if (client.root_window_click_fix === true) {
+				client.do_window_mouse_click(ev, null, true);
+				client.do_window_mouse_click(ev, null, false);
+			}
 		}
 		jQuery("#head"+String(this.wid)).click(root_window_click);
 		jQuery(this.div).on("dragstart",function(ev,ui){


### PR DESCRIPTION
The `root_window_click()` fix/workaround can cause problems in some situations
(ex: when dragging over other maximized windows, causing them to raise),
so this gates the fix behind a `default_settings`-based flag.

Idea & implementation credit: @danisla