### PR TITLE
move the auto-fullscreen feature out of request_redraw

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -610,6 +610,23 @@ XpraClient.prototype._screen_resized = function(event, ctx) {
 		const iwin = ctx.id_to_window[i];
 		iwin.screen_resized();
 	}
+	// Force fullscreen on a a given window name from the provided settings
+	if (default_settings !== undefined && default_settings.auto_fullscreen !== undefined && default_settings.auto_fullscreen.length > 0) {
+		var pattern = new RegExp(".*" + default_settings.auto_fullscreen + ".*");
+		if (iwin.fullscreen === false && iwin.metadata.title.match(pattern)) {
+			clog("auto fullscreen window: " + iwin.metadata.title);
+			iwin.set_fullscreen(true);
+			iwin.screen_resized();
+		}
+	}
+
+	// Make a DESKTOP-type window fullscreen automatically.
+	// This resizes things like xfdesktop according to the window size.
+	if (iwin.fullscreen === false && client.is_window_desktop(iwin)) {
+		clog("auto fullscreen desktop window: " + iwin.metadata.title);
+		iwin.set_fullscreen(true);
+		iwin.screen_resized();
+	}
 	// Re-position floating toolbar menu
 	this.position_float_menu();
 };
@@ -3181,24 +3198,6 @@ XpraClient.prototype._process_eos = function(packet, ctx) {
 
 
 XpraClient.prototype.request_redraw = function(win) {
-
-	// Force fullscreen on a a given window name from the provided settings
-	if (default_settings !== undefined && default_settings.auto_fullscreen !== undefined && default_settings.auto_fullscreen.length > 0) {
-		var pattern = new RegExp(".*" + default_settings.auto_fullscreen + ".*");
-		if (win.fullscreen === false && win.metadata.title.match(pattern)) {
-			clog("auto fullscreen window: " + win.metadata.title);
-			win.set_fullscreen(true);
-			win.screen_resized();
-		}
-	}
-
-	// Make a DESKTOP-type window fullscreen automatically.
-	// This resizes things like xfdesktop according to the window size.
-	if (win.fullscreen === false && client.is_window_desktop(win)) {
-		clog("auto fullscreen desktop window: " + win.metadata.title);
-		win.set_fullscreen(true);
-		win.screen_resized();
-	}
 
 	if (document.hidden) {
 		this.debug("draw", "not redrawing, document.hidden=", document.hidden);


### PR DESCRIPTION
auto-fullscreen was being evaluated in the request_redraw handler to cover cases where resizing the browser window would break the target auto-fullscreen window.

Moved this functionality into the client _screen_resized handler instead.

Working as expected in my tests.