### PR TITLE
Fix missing root for install_dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,7 @@ def install_html5(root="/", install_dir="/usr/share/xpra/www/", config_dir="/etc
         if paths:
             extra_symlinks = {"background.png" : paths}
             for f, symlink_options in extra_symlinks.items():
-                dst = os.path.join(root, install_dir, f)
+                dst = os.path.join(root+install_dir, f)
                 if install_symlink(symlink_options, dst):
                     break
 

--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,8 @@ def install_html5(root="/", install_dir="/usr/share/xpra/www/", config_dir="/etc
             dst = os.path.join(root+install_dir, fname)
             if os.path.exists(dst):
                 os.unlink(dst)
+            elif not os.path.exists(root+install_dir):
+                os.makedirs(root+install_dir, 0o755)
             if fname in configuration_files and config_dir and config_dir!=install_dir:
                 #install configuration files in `config_dir` in root:
                 cdir = root+config_dir
@@ -253,8 +255,8 @@ def install_html5(root="/", install_dir="/usr/share/xpra/www/", config_dir="/etc
                 shutil.copyfile(src, config_file)
                 os.chmod(config_file, 0o644)
                 #and create a symlink from `install_dir`:
-                #pointing to the config_file without the root:
-                config_file = os.path.join(config_dir, fname)
+                #pointing to the config_file:
+                config_file = os.path.join(cdir, fname)
                 os.symlink(config_file, dst)
                 print("config file symlinked: %s -> %s" % (dst, config_file))
                 continue


### PR DESCRIPTION
Avoids...

```sh
$ ./setup.py install $HOME/junk /var/lib/www /etc/xpra-html5
...
symlinked /var/lib/www/background.png from /usr/share/backgrounds/gnome/adwaita-day.jpg
Traceback (most recent call last):
  File "/mnt/host/source/xpra-html5/./setup.py", line 582, in <module>
    sys.exit(main(sys.argv))
  File "/mnt/host/source/xpra-html5/./setup.py", line 564, in main
    install_html5(root_dir, install_dir, config_dir, minifier=minifier)
  File "/mnt/host/source/xpra-html5/./setup.py", line 375, in install_html5
    if install_symlink(symlink_options, dst):
  File "/mnt/host/source/xpra-html5/./setup.py", line 62, in install_symlink
    os.makedirs(ddir, mode=0o755)
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/var/lib/www'
```