### PR TITLE
Rename GitHub Actions workflow & job for accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 
-name: HTML5
+name: CI
 
 on: [push, pull_request]
 
@@ -8,7 +8,8 @@ defaults:
     shell: bash
 
 jobs:
-  install_nix_native:
+
+  test_installation_methods:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
In using this one-job workflow, I noticed that the names of the workflow & job are not very descriptive or accurate.

<img width="463" alt="Screen Shot 2022-05-21 at 8 51 17 PM" src="https://user-images.githubusercontent.com/4754114/169676179-25e56a80-3f71-4c76-a0b6-b10893cab09a.png">

---

What do you think of these new names?

<img width="491" alt="Screen Shot 2022-05-21 at 8 53 04 PM" src="https://user-images.githubusercontent.com/4754114/169676178-d03d85c1-656e-4612-9ff7-d4edd0d70b0a.png">
