### PR TITLE
Fix comparison value stringiness

### DIFF
--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -561,7 +561,7 @@ const Utilities = {
 		}
 		let value = getParameter(prop);
 		try {
-			if (value === undefined && typeof(sessionStorage) !== undefined) {
+			if (value === undefined && typeof(sessionStorage) !== "undefined") {
 				value = sessionStorage.getItem(prop);
 			}
 		}


### PR DESCRIPTION
`typeof` can return `"undefined"` but not `undefined`. The current implementation is certainly not intentional, but I don't know if this fix will cause any bugs.