### PR TITLE
Remove all commented-out code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # eclipse IDE:
-# /
 /.project
 /.pydevproject
 

--- a/html5/connect.html
+++ b/html5/connect.html
@@ -1564,9 +1564,6 @@
           "exit_with_client",
         ];
         //even on 64-bit, video decoding is too slow
-        //if (Utilities.is_64bit()) {
-        //	default_on.push("video");
-        //}
         if (Utilities.isMacOS()) {
           default_on.push("swap_keys");
         }

--- a/html5/css/simple-keyboard.css
+++ b/html5/css/simple-keyboard.css
@@ -101,4 +101,3 @@
 .hg-theme-default .hg-button.hg-standardBtn[data-skbtn="@"] {
   max-width: 60px;
 }
-/*# sourceMappingURL=simple-keyboard.css.map */

--- a/html5/index.html
+++ b/html5/index.html
@@ -557,7 +557,6 @@
           const info = e.data;
           $("#endpoint").html(client.uri);
           $("#server_display").html(client.server_display);
-          //$("#server_hostname").html(info["hostname"] || "");
           $("#server_platform").html(client.server_platform);
           if (client.server_load == null) {
             $("#server_load").html("n/a");
@@ -574,9 +573,6 @@
             s += ":" + ("0" + ss).slice(-2); //left pad with "0"
             return s;
           }
-          //this one shows bogus values!?:
-          //var elapsed = (new Date()).getTime()-info["server.start_time"];
-          //$("#session_started").html(toHHMMSS(elapsed));
           const elapsed = new Date().getTime() - client.client_start_time;
           $("#session_connected").html(toHHMMSS(elapsed));
           if (client.server_ping_latency >= 0)
@@ -900,11 +896,11 @@
         client.scroll_reverse_y = scroll_reverse_y;
         client.vrefresh = vrefresh;
         client.scale = scale;
-        //example overrides:
-        //client.HELLO_TIMEOUT = 3600000;
-        //client.PING_TIMEOUT = 60000;
-        //client.PING_GRACE = 30000;
-        //client.PING_FREQUENCY = 15000;
+        // example overrides:
+        //   `client.HELLO_TIMEOUT = 3600000;`
+        //   `client.PING_TIMEOUT = 60000;`
+        //   `client.PING_GRACE = 30000;`
+        //   `client.PING_FREQUENCY = 15000;`
 
         if (debug) {
           //example of client event hooks:
@@ -1042,7 +1038,6 @@
                 ssl: ssl,
                 path: path,
                 encryption: encryption,
-                //"key"				: key,
                 encoding: encoding,
                 bandwidth_limit: bandwidth_limit,
                 keyboard_layout: keyboard_layout,

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -330,7 +330,6 @@ class XpraClient {
   debug() {
     const category = arguments[0];
     let args = Array.from(arguments);
-    //args = args.splice(1);
     if (this.debug_categories.includes(category)) {
       if (category != "network") {
         //logging.DEBUG = 10
@@ -864,7 +863,6 @@ class XpraClient {
       index = new_modifiers.indexOf(control);
       if (index >= 0) new_modifiers.splice(index, 1);
     }
-    //this.clog("altgr_state=", this.altgr_state, ", altgr_modifier=", this.altgr_modifier, ", modifiers=", new_modifiers);
     return new_modifiers;
   }
 
@@ -1053,9 +1051,6 @@ class XpraClient {
       str = "AltGraph";
     }
 
-    //if (this.num_lock && keycode>=96 && keycode<106)
-    //	keyname = "KP_"+(keycode-96);
-
     const raw_modifiers = get_event_modifiers(event);
     const modifiers = this._keyb_get_modifiers(event);
     const keyval = keycode;
@@ -1225,7 +1220,6 @@ class XpraClient {
       kc = parseInt(keycode);
       keycodes.push([kc, CHARCODE_TO_NAME[keycode], kc, 0, 0]);
     }
-    //show("keycodes="+keycodes.toSource());
     return keycodes;
   }
 
@@ -1237,7 +1231,6 @@ class XpraClient {
     "use strict";
     const dpi_div = document.getElementById("dpi");
     if (dpi_div != undefined) {
-      //show("dpiX="+dpi_div.offsetWidth+", dpiY="+dpi_div.offsetHeight);
       if (dpi_div.offsetWidth > 0 && dpi_div.offsetHeight > 0)
         return Math.round((dpi_div.offsetWidth + dpi_div.offsetHeight) / 2.0);
     }
@@ -1285,7 +1278,6 @@ class XpraClient {
   _check_server_echo(ping_sent_time) {
     const last = this.server_ok;
     this.server_ok = this.last_ping_echoed_time >= ping_sent_time;
-    //this.clog("check_server_echo", this.server_ok, "last", last, "last_time", this.last_ping_echoed_time, "this_this", ping_sent_time);
     if (last != this.server_ok) {
       if (!this.server_ok) {
         this.clog("server connection is not responding, drawing spinners...");
@@ -1552,7 +1544,6 @@ class XpraClient {
         "iconic",
         "above",
         "below",
-        //"set-initial-position", "group-leader",
         "title",
         "size-hints",
         "class-instance",
@@ -1564,7 +1555,6 @@ class XpraClient {
         "tray",
         "modal",
         "opacity",
-        //"shadow", "desktop",
       ],
       encoding: this.encoding,
       encodings: this.supported_encodings,
@@ -1577,11 +1567,12 @@ class XpraClient {
       "encoding.transparency": true,
       "encoding.decoder-speed": { video: 0 },
       "encodings.packet": true,
-      //"encoding.min-speed"		: 80,
-      //"encoding.min-quality"	: 50,
-      "encoding.color-gamut": Utilities.getColorGamut(),
-      //"encoding.non-scroll"		: ["rgb32", "png", "jpeg"],
+      //skipping some keys
+      //ie: "encoding.min-quality": 50,
+      //ie: "encoding.min-speed": 80,
+      //ie: "encoding.non-scroll": ["rgb32", "png", "jpeg"],
       //video stuff:
+      "encoding.color-gamut": Utilities.getColorGamut(),
       "encoding.video_scaling": true,
       "encoding.video_max_size": [1024, 768],
       "encoding.eos": true,
@@ -1617,9 +1608,7 @@ class XpraClient {
       "encoding.h264.score-delta": -20,
       "encoding.h264+mp4.score-delta": 50,
       "encoding.h264+mp4.": 50,
-      //"encoding.h264+mp4.fast-decode"		: true,
       "encoding.mpeg4+mp4.score-delta": 40,
-      //"encoding.mpeg4+mp4.fast-decode"	: true,
       "encoding.vp8+webm.score-delta": 40,
 
       "sound.receive": true,
@@ -1754,7 +1743,6 @@ class XpraClient {
   }
 
   _window_mouse_up(ctx, e, window) {
-    //this.mousedown_event = null;
     ctx.do_window_mouse_click(e, window, false);
   }
 
@@ -2002,12 +1990,6 @@ class XpraClient {
         this.clog("paste got", files.length, "files");
         for (let i = 0; i < files.length; i++) {
           let file = files.item(i);
-          //lastModified: 1634740745068
-          //lastModifiedDate: Wed Oct 20 2021 21:39:05 GMT+0700 (Indochina Time) {}
-          //name: "addresses.png"
-          //size: 17698
-          //type: "image/png"
-          //webkitRelativePath: ""
           this.send_file(file);
         }
         e.preventDefault();
@@ -2269,7 +2251,6 @@ class XpraClient {
       iwin.updateFocus();
       iwin.update_zindex();
     }
-    //client._set_favicon(wid);
   }
 
   /*
@@ -2614,7 +2595,6 @@ class XpraClient {
   }
 
   _process_hello(packet) {
-    //show("process_hello("+packet+")");
     this.cancel_hello_timer();
     const hello = packet[1];
     this.clog("received hello capabilities", hello);
@@ -2717,7 +2697,6 @@ class XpraClient {
     if ("modifier_keycodes" in hello) {
       const modifier_keycodes = hello["modifier_keycodes"];
       for (const mod in modifier_keycodes) {
-        //show("modifier_keycode["+mod+"]="+modifier_keycodes[mod].toSource());
         const keys = modifier_keycodes[mod];
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i];
@@ -2734,7 +2713,6 @@ class XpraClient {
         }
       }
     }
-    //show("alt="+alt_modifier+", meta="+meta_modifier);
     // stuff that must be done after hello
     if (this.audio_enabled) {
       if (!hello["sound.send"]) {
@@ -3205,8 +3183,6 @@ class XpraClient {
 
   _process_new_tray(packet) {
     const wid = packet[1];
-    //let w = packet[2];
-    //let h = packet[3];
     const metadata = packet[4];
     const mydiv = document.createElement("div");
     mydiv.id = String(wid);
@@ -3619,7 +3595,6 @@ class XpraClient {
   }
 
   _process_desktop_size(packet) {
-    //root_w, root_h, max_w, max_h = packet[1:5]
     //we don't use this yet,
     //we could use this to clamp the windows to a certain area
   }
@@ -3653,10 +3628,6 @@ class XpraClient {
    */
   _process_notify_show(packet) {
     //TODO: add UI switch to disable notifications
-    //unused:
-    //const dbus_id = packet[1];
-    //const app_name = packet[3];
-    //const app_icon = packet[5];
     const nid = packet[2];
     const replaces_nid = packet[4];
     const summary = Utilities.s(packet[6]);
@@ -3679,17 +3650,6 @@ class XpraClient {
         icon_url = "data:image/png;base64," + Utilities.ToBase64(icon[3]);
         this.clog("notification icon_url=", icon_url);
       }
-      /*
-			const nactions = [];
-			if (actions) {
-				ctx.log("actions=", actions);
-				for (let i=0; i<actions.length/2;++i) {
-					nactions.push({
-						"action"	: actions[i*2],
-						"title"		: actions[i*2+1],
-					});
-				}
-			}*/
       const notification = new Notification(summary, {
         body: body,
         icon: icon_url,
@@ -4467,13 +4427,7 @@ class XpraClient {
       this.audio_source_buffer.appendBuffer(buf);
       const b = this.audio_source_buffer.buffered;
       if (b && b.length >= 1) {
-        //for (let i=0; i<b.length;i++) {
-        //	this.clog("buffered[", i, "]=", b.start(i), b.end(i));
-        //}
         const p = this.audio.played;
-        //for (let i=0; i<p.length;i++) {
-        //	this.clog("played[", i, "]=", p.start(i), p.end(i));
-        //}
         const e = b.end(0);
         const buf_size = Math.round(1000 * (e - this.audio.currentTime));
         this.debug(
@@ -4515,8 +4469,6 @@ class XpraClient {
         "demuxer=",
         this.audio_aurora_ctx.demuxer
       );
-      //"source=", this.audio_aurora_ctx.asset.source,
-      //"events=", this.audio_aurora_ctx.asset.source.events);
     }
     this.on_audio_state_change("playing", "");
   }
@@ -4684,7 +4636,6 @@ class XpraClient {
     // unless we have support for navigator.clipboard:
     const request_id = packet[1],
       selection = packet[2];
-    //target = packet[3];
 
     this.debug("clipboard", selection + " request");
 
@@ -5471,7 +5422,6 @@ class XpraClient {
 
   _process_open_url(packet) {
     const url = packet[1];
-    //const send_id = packet[2];
     if (!this.open_url) {
       this.cwarn("Warning: received a request to open URL", url);
       this.clog(" but opening of URLs is disabled");

--- a/html5/js/DecodeWorker.js
+++ b/html5/js/DecodeWorker.js
@@ -28,9 +28,7 @@ function decode_draw_packet(packet, start) {
     height = packet[5],
     coding = packet[6],
     packet_sequence = packet[8];
-  //console.log("decode worker sequence "+packet_sequence+": start="+start);
   function send_back(raw_buffers) {
-    //console.log("send_back: wid_hold=", wid_hold);
     const wid_hold = on_hold.get(wid);
     if (wid_hold) {
       //find the highest sequence number which is still lower than this packet
@@ -66,7 +64,6 @@ function decode_draw_packet(packet, start) {
       wid_hold = new Map();
       on_hold.set(wid, wid_hold);
     }
-    //console.log("holding=", packet_sequence);
     wid_hold.set(packet_sequence, []);
     return wid_hold;
   }
@@ -79,7 +76,6 @@ function decode_draw_packet(packet, start) {
     }
     //release any packets held back by this image:
     const held = wid_hold.get(packet_sequence);
-    //console.log("release held=", held);
     if (!held) {
       //could have been cancelled by EOS
       return;
@@ -91,7 +87,6 @@ function decode_draw_packet(packet, start) {
       do_send_back(held_packet, held_raw_buffers);
     }
     wid_hold.delete(packet_sequence);
-    //console.log("wid_hold=", wid_hold, "on_hold=", on_hold);
     if (wid_hold.size == 0 && on_hold.has(wid)) {
       //this was the last held sequence for this window
       on_hold.delete(wid);
@@ -196,7 +191,6 @@ function decode_draw_packet(packet, start) {
         close_broadway();
         decoder = null;
       }
-      //console.log("decoder=", decoder);
       if (!decoder) {
         decoder = new Decoder({
           rgb: true,
@@ -207,7 +201,6 @@ function decode_draw_packet(packet, start) {
       }
       let count = 0;
       decoder.onPictureDecoded = function (buffer, p_width, p_height, infos) {
-        //console.log("broadway frame: enc size=", enc_width, enc_height, ", decode size=", p_width, p_height);
         count++;
         //forward it as rgb32:
         send_rgb32_back(buffer, p_width, p_height, bitmap_options);

--- a/html5/js/Keycodes.js
+++ b/html5/js/Keycodes.js
@@ -1625,13 +1625,11 @@ KEYSYM_TO_UNICODE = {
 CHAR_TO_NAME = {
   " ": "space",
 };
-//console.debug("KEYSYM_TO_UNICODE=", KEYSYM_TO_UNICODE);
 for (let keysym in KEYSYM_TO_UNICODE) {
   const u = KEYSYM_TO_UNICODE[keysym];
   const character = String.fromCharCode(u);
   CHAR_TO_NAME[character] = keysym;
 }
-//console.debug("CHAR_TO_NAME=", KEYSYM_TO_UNICODE);
 
 //some keysyms require specific layouts
 KEYSYM_TO_LAYOUT = {
@@ -1730,8 +1728,7 @@ for (let i = 0; i < 26; i++) {
 for (let i = 0; i < 10; i++) {
   CHARCODE_TO_NAME[48 + i] = "" + i;
   CHARCODE_TO_NAME[96 + i] = "" + i;
-  //fix for OSX numpad?
-  //CHARCODE_TO_NAME[96+i] = "KP_"+i;
+  //fix for OSX numpad?: CHARCODE_TO_NAME[96+i] = "KP_"+i;
 }
 for (let i = 1; i <= 24; i++) {
   CHARCODE_TO_NAME[111 + i] = "F" + i;

--- a/html5/js/MediaSourceUtil.js
+++ b/html5/js/MediaSourceUtil.js
@@ -27,14 +27,9 @@ const MediaSourceConstants = {
 
   CODEC_STRING: {
     "aac+mpeg4": 'audio/mp4; codecs="mp4a.40.2"',
-    //"aac+mpeg4"		: 'audio/mp4; codecs="aac51"',
-    //"aac+mpeg4"		: 'audio/aac',
     mp3: "audio/mpeg",
     "mp3+mpeg4": 'audio/mp4; codecs="mp3"',
-    //"mp3"			: "audio/mp3",
     ogg: "audio/ogg",
-    //"wave"		: 'audio/wave',
-    //"wav"			: 'audio/wav; codec="1"',
     wav: "audio/wav",
     flac: "audio/flac",
     "opus+mka": 'audio/webm; codecs="opus"',
@@ -64,7 +59,6 @@ const MediaSourceConstants = {
   ],
 
   H264_PROFILE_CODE: {
-    //"baseline"	: "42E0",
     baseline: "42C0",
     main: "4D40",
     high: "6400",

--- a/html5/js/Menu-custom.js
+++ b/html5/js/Menu-custom.js
@@ -127,7 +127,6 @@ $(function () {
   });
   float_menu.on("dragstart", function (ev, ui) {
     client.mouse_grabbed = true;
-    //set_focus_cb(0);
   });
   float_menu.on("dragstop", function (ev, ui) {
     client.mouse_grabbed = false;

--- a/html5/js/Notifications.js
+++ b/html5/js/Notifications.js
@@ -77,8 +77,6 @@ $(function () {
     notifications_elements.prepend(a);
     if (icon) {
       const encoding = icon[0],
-        //w = icon[1],
-        //h = icon[2],
         img_data = icon[3];
       if (encoding == "png") {
         const src =

--- a/html5/js/Protocol.js
+++ b/html5/js/Protocol.js
@@ -346,7 +346,6 @@ class XpraProtocol {
       while (rsize < packet_size) {
         const slice = this.rQ[0];
         const needed = packet_size - rsize;
-        //console.log("slice:", slice.length, "bytes, needed", needed);
         if (slice.length > needed) {
           //add part of this slice:
           packet_data.set(slice.subarray(0, needed), rsize);
@@ -396,13 +395,11 @@ class XpraProtocol {
       } else {
         inflated = new Zlib.Inflate(packet_data).decompress();
       }
-      //debug("inflated("+packet_data+")="+inflated);
       packet_data = inflated;
     }
 
     //save it for later? (partial raw packet)
     if (index > 0) {
-      //debug("added raw packet for index "+index);
       this.raw_packets[index] = packet_data;
       if (this.raw_packets.length >= 4) {
         this.protocol_error("too many raw packets: " + this.raw_packets.length);
@@ -465,7 +462,6 @@ class XpraProtocol {
       } catch (e) {
         //FIXME: maybe we should error out and disconnect here?
         this.error("error processing packet " + packet[0] + ": " + e);
-        //this.error("packet_data="+packet_data);
       }
     }
     return this.rQ.length > 0;
@@ -590,7 +586,6 @@ class XpraProtocol {
     this.setup_cipher(caps, key, (cipher, block_size, secret, iv) => {
       this.cipher_in_block_size = block_size;
       this.cipher_in = forge.cipher.createDecipher(cipher, secret);
-      //this.cipher_in.start({"iv": iv, "tagLength" : 0, "tag" : ""});
       this.cipher_in.start({ iv: iv });
     });
   }

--- a/html5/js/RgbHelpers.js
+++ b/html5/js/RgbHelpers.js
@@ -21,7 +21,6 @@ function decode_rgb(packet) {
     data = lz4.decode(data);
     delete options["lz4"];
   }
-  //this.debug("draw", "got ", data.length, "bytes of", coding, "to paint with stride", rowstride);
   if (coding == "rgb24") {
     packet[9] = width * 4;
     packet[6] = "rgb32";

--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -199,7 +199,6 @@ const Utilities = {
     for (let i = 0; i < browserLanguagePropertyKeys.length; i++) {
       const prop = browserLanguagePropertyKeys[i];
       language = nav[prop];
-      //Utilities.debug(prop, "=", language);
       if (language && language.length) {
         return language;
       }
@@ -727,22 +726,13 @@ const LANGUAGE_TO_LAYOUT = {
   zh: "cn",
   af: "za",
   sq: "al",
-  //"ar"	: "ar",
-  //"eu"	: "eu",
-  //"bg"	: "bg",
-  //"be"	: "be",
   ca: "ca",
   "zh-TW": "tw",
   "zh-CN": "cn",
-  //"zh-HK"	: ??
-  //"zh-SG"	: ??
-  //"hr"	: "hr",
   cs: "cz",
   da: "dk",
-  //"nl"	: "nl",
   "nl-BE": "be",
   "en-US": "us",
-  //"en-EG"	: ??
   "en-AU": "us",
   "en-GB": "gb",
   "en-CA": "ca",
@@ -750,67 +740,51 @@ const LANGUAGE_TO_LAYOUT = {
   "en-IE": "ie",
   "en-ZA": "za",
   "en-JM": "us",
-  //"en-BZ"	: ??
   "en-TT": "tr",
   et: "ee",
-  //"fo"	: "fo",
   fa: "ir",
-  //"fi"	: "fi",
-  //"fr"	: "fr",
   "fr-BE": "be",
   "fr-CA": "ca",
   "fr-CH": "ch",
   "fr-LU": "fr",
-  //"gd"	: ??
   "gd-IE": "ie",
-  //"de"	: "de",
   "de-CH": "ch",
   "de-AT": "at",
   "de-LU": "de",
   "de-LI": "de",
   he: "il",
   hi: "in",
-  //"hu"	: "hu",
-  //"is"	: "is",
-  //"id"	: ??,
-  //"it"	: "it",
   "it-CH": "ch",
   ja: "jp",
   ko: "kr",
-  //"lv"	: "lv",
-  //"lt"	: "lt",
-  //"mk"	: "mk",
-  //"mt"	: "mt",
-  //"no"	: "no",
-  //"pl"	: "pl",
   "pt-BR": "br",
   pt: "pt",
-  //"rm"	: ??,
-  //"ro"	: "ro",
-  //"ro-MO"	: ??,
-  //"ru"	: "ru",
-  ///"ru-MI"	: ??,
-  //"sz"	: ??,
   sr: "rs",
-  //"sk"	: "sk",
   sl: "si",
-  //"sb"	: ??,
   es: "es",
-  //"es-AR", "es-GT", "es-CR", "es-PA", "es-DO", "es-MX", "es-VE", "es-CO",
-  //"es-PE", "es-EC", "es-CL", "es-UY", "es-PY", "es-BO", "es-SV", "es-HN",
-  //"es-NI", "es-PR",
-  //"sx"	: ??,
   sv: "se",
   "sv-FI": "fi",
-  //"th"	: "th",
-  //"ts"	: ??,
-  //"tn"	: ??,
   tr: "tr",
   uk: "ua",
   ur: "pk",
-  //"ve"	: ??,
   vi: "vn",
-  //"xh"	: "??",
-  //"ji"	: "??",
-  //"zu"	: "??",
+  //Unknown conversions
+  //"en-BZ": ??
+  //"en-EG": ??
+  //"gd": ??
+  //"id": ??
+  //"ji": ??
+  //"rm": ??
+  //"ro-MO": ??
+  //"ru-MI": ??
+  //"sb": ??
+  //"sx": ??
+  //"sz": ??
+  //"ts": ??
+  //"tn": ??
+  //"ve": ??
+  //"xh": ??
+  //"zh-HK": ??
+  //"zh-SG": ??
+  //"zu": ??
 };

--- a/html5/js/Window.js
+++ b/html5/js/Window.js
@@ -215,9 +215,6 @@ class XpraWindow {
       helper: "ui-resizable-helper",
       handles: "n, e, s, w, ne, se, sw, nw",
     });
-    //jQuery(this.div).on("resize",jQuery.debounce(50, (ev, ui) => {
-    //  	this.handle_resized(ui);
-    //}));
     jQuery(this.div).on("resizestart", (ev, ui) => {
       client.do_window_mouse_click(ev, this, false);
       client.mouse_grabbed = true;
@@ -253,9 +250,6 @@ class XpraWindow {
     jQuery(this.div).mousedown((e) => e.stopPropagation());
     //bug 2418: if we stop 'mouseup' propagation,
     //jQuery can't ungrab the window with Firefox
-    //jQuery(this.div).mouseup(function (e) {
-    //	e.stopPropagation();
-    //});
     // assign callback to focus window if header is clicked.
     jQuery(this.d_header).click((e) => {
       if (
@@ -394,7 +388,6 @@ class XpraWindow {
     const desktop_size = this.client._get_desktop_size();
     const ww = desktop_size[0];
     const wh = desktop_size[1];
-    //this.log("x=", this.x, "y=", this.y, "w=", this.w, "h=", this.h, "leftoffset=", this.leftoffset, "topoffset=", this.topoffset, " - ww=", ww, "wh=", wh);
     if (oldx < this.leftoffset && oldx + this.w <= min_visible) {
       this.x = min_visible - this.w + this.leftoffset;
     } else if (oldx >= ww - min_visible) {
@@ -536,7 +529,6 @@ class XpraWindow {
 
   on_mousescroll(e) {
     this.mouse_scroll_cb(this.client, e, this);
-    //e.preventDefault();
     return false;
   }
 
@@ -849,7 +841,6 @@ class XpraWindow {
    * Toggle minimized state
    */
   toggle_minimized() {
-    //console.error("toggle_minimized minimized=", this.minimized);
     //get the geometry before modifying the window:
     const geom = this.get_internal_geometry();
     this.set_minimized(!this.minimized);
@@ -880,8 +871,8 @@ class XpraWindow {
    */
   set_fullscreen(fullscreen) {
     //the browser itself:
-    //we can't bring attention to the fullscreen widget, ie:
-    //$("#fullscreen").fadeIn(100).fadeOut(100).fadeIn(100).fadeOut(100).fadeIn(100);
+    //we can't bring attention to the fullscreen widget,
+    //ie: $("#fullscreen").fadeIn(100).fadeOut(100).fadeIn(100).fadeOut(100).fadeIn(100);
     //because the window is about to cover the top bar...
     //so just fullscreen the window:
     if (this.fullscreen == fullscreen) {
@@ -989,7 +980,6 @@ class XpraWindow {
     this.debug("geometry", "handle_moved(", e, ") left=", left, ", top=", top);
     // add on padding to the event position so that
     // it reflects the internal geometry of the canvas
-    //this.log("handle moved: position=", e.position.left, e.position.top);
     this.x = left + this.leftoffset;
     this.y = top + this.topoffset;
     // make sure we are visible after move
@@ -1165,7 +1155,6 @@ class XpraWindow {
       e.type = "mousedown.draggable";
       e.target = this.div[0];
       this.div.trigger(e);
-      //jQuery(this.div).trigger("mousedown");
     } else if (direction == MOVERESIZE_CANCEL) {
       jQuery(this.div).draggable("disable");
       jQuery(this.div).draggable("enable");

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ def install_symlink(symlink_options, dst):
                     os.makedirs(ddir, mode=0o755)
             os.symlink(symlink_option, dst)
             return True
-    #print("no symlinks found for %s from %s" % (dst, symlink_options))
     return False
 
 


### PR DESCRIPTION
I don't know which of these lines were commented-out temporarily, accidentally, or for documentation. Regardless, commented-out code presents unnecessary cognitive load during onboarding, development, and maintenance. Therefore, we should remove non-documentation comments and visually distinguish permanent documentation comments from simply-temporary/accidental `//` insertions. Please let me know if any of these comment deletions go too far!