### PR TITLE
fix windows movement with Xpra 3.1.x

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -1364,6 +1364,7 @@ XpraClient.prototype._make_hello = function() {
 		"randr_notify"				: true,
 		"sound.server_driven"		: true,
 		"server-window-resize"		: true,
+		"window.initiate-moveresize"	: true,
 		"screen-resize-bigger"		: false,
 		"metadata.supported"		: [
 										"fullscreen", "maximized", "iconic", "above", "below",


### PR DESCRIPTION
According to the readme, the client is compatible "with any currently supported version". Xpra 3.1.x is still listed as supported. Hence, I assume it's a bug.

The PR is against the 5.x branch, since master is completely broken with Xpra 3.1.x due to the switch to rencodeplus. Not sure if it's intended.

The bug is present in the 4.x branch as well, but no idea if this branch is still supported. If it is, please consider backporting to 4.x.