### PR TITLE
fix Protocol.js to enable tcp-encryption

### DIFF
--- a/html5/js/Protocol.js
+++ b/html5/js/Protocol.js
@@ -234,6 +234,14 @@ class XpraProtocol {
     console.log.apply(console, arguments);
   }
 
+  StringToUint8(string_) {
+    return Uint8Array.from([...string_].map((x) => x.charCodeAt(0)));
+  }
+
+  ord(c) {
+    return c.charCodeAt(0);
+  }
+
   do_process_receive_queue() {
     if (this.header.length < 8 && this.rQ.length > 0) {
       //add from receive queue data to header until we get the 8 bytes we need:
@@ -352,7 +360,7 @@ class XpraProtocol {
 
     // decrypt if needed
     if (proto_crypto) {
-      this.cipher_in.update(forge.util.createBuffer(uintToString(packet_data)));
+      this.cipher_in.update(forge.util.createBuffer(Uint8ToString(packet_data)));
       const decrypted = this.cipher_in.output.getBytes();
       if (!decrypted || decrypted.length < packet_size - padding) {
         this.error("error decrypting packet using", this.cipher_in);
@@ -368,7 +376,7 @@ class XpraProtocol {
         this.raw_packets = [];
         return this.rQ.length > 0;
       }
-      packet_data = Utilities.StringToUint8(
+      packet_data = this.StringToUint8(
         decrypted.slice(0, packet_size - padding)
       );
     }
@@ -464,7 +472,7 @@ class XpraProtocol {
           this.cipher_out_block_size -
           (payload_size % this.cipher_out_block_size);
         let input_data =
-          typeof bdata === "string" ? bdata : Utilities.Uint8ToString(bdata);
+          typeof bdata === "string" ? bdata : Uint8ToString(bdata);
         if (padding_size) {
           const padding_char = String.fromCharCode(padding_size);
           input_data += padding_char.repeat(padding_size);
@@ -490,7 +498,7 @@ class XpraProtocol {
       } else {
         //copy string one character at a time..
         for (let index = 0; index < actual_size; index++) {
-          packet_data[8 + index] = ord(bdata[index]);
+          packet_data[8 + index] = this.ord(bdata[index]);
         }
       }
       // put into buffer before send


### PR DESCRIPTION
This fixes issues I had with tcp-encryption in combination with the html5 client.
With this MR I can connect from the browser to a xpra server started with:
`xpra start --start=xterm --bind-tcp=0.0.0.0:10000 --html=on --tcp-encryption=AES --tcp-encryption-keyfile=auth.txt`

- uintToString(..) does not exist. Hence, Uint8ToString(..) from lib/rencode.js imported at line 627 is used
- Utilities is not in scope so Utilities.StringToUint8(..) fails. Hence, StringToUint8(..) got added to class XpraProtocol
- Utilities is not in scope so Utilities.Uint8ToString(..) fails. Hence, Uint8ToString(..) from lib/rencode.js imported at line 627 is used
- ord(..) is not defined. Hence, ord(..) got added to class XpraProtocol

I couldn't figure out why Utilities is out of scope in places where it is needed in Protocol.js - that's a mystery to me.
First I thought it is because of the wrong order Utilities.js and Protocol.js is included in index.html - but fixing this did not help. 
(btw: another thing I came across was that Uint8ToString() is defined in Utilities.js and rencode.js the same way ... )