### PR TITLE
Use TextEncoder/TextDecoder to handle string conversion to/from UTF-8

### DIFF
--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -423,19 +423,12 @@ const Utilities = {
     }
   },
 
-  StringToUint8(string_) {
-    return Uint8Array.from([...string_].map((x) => x.charCodeAt(0)));
+  StringToUint8(value) {
+    return new TextEncoder().encode(value);
   },
 
-  Uint8ToString(u8a) {
-    const CHUNK_SZ = 0x80_00;
-    const c = [];
-    for (let index = 0; index < u8a.length; index += CHUNK_SZ) {
-      c.push(
-        String.fromCharCode.apply(null, u8a.subarray(index, index + CHUNK_SZ))
-      );
-    }
-    return c.join("");
+  Uint8ToString(value) {
+    return new TextDecoder().decode(value);
   },
 
   s(v) {


### PR DESCRIPTION
This fixes a decoding issue when copying UTF-8 characters (that are not ASCII) from the web-client to the host by using the built-in text encoding/decoding functionality ([TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder), [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)).
As a result, the code is significantly easier to read and understand, however this does break compatibility with IE.