### PR TITLE
Fix encoding issue when using authentication.

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -2019,34 +2019,28 @@ class XpraClient {
         e.preventDefault();
         return;
       }
-      let paste_data;
       if (navigator.clipboard && navigator.clipboard.readText) {
         navigator.clipboard.readText().then(
           (text) => {
             this.cdebug("clipboard", "paste event, text=", text);
-            const paste_data = unescape(encodeURIComponent(text));
-            this.clipboard_buffer = paste_data;
-            this.send_clipboard_token(paste_data);
+            this.clipboard_buffer = text;
+            const data = Utilities.StringToUint8(text);
+            this.send_clipboard_token(data);
           },
           (error) => this.cdebug("clipboard", "paste event failed:", error)
         );
       } else {
-        let datatype = TEXT_PLAIN;
-        if (Utilities.isIE()) {
-          datatype = "Text";
-        }
-        paste_data = unescape(
-          encodeURIComponent(clipboardData.getData(datatype))
-        );
-        cdebug("clipboard", "paste event, data=", paste_data);
-        this.clipboard_buffer = paste_data;
-        this.send_clipboard_token(paste_data);
+        const text = clipboardData.getData(TEXT_PLAIN);
+        cdebug("clipboard", "paste event, text=", text);
+        this.clipboard_buffer = text;
+        const data = Utilities.StringToUint8(text);
+        this.send_clipboard_token(data);
       }
     });
     window.addEventListener("copy", (e) => {
       const clipboard_buffer = this.get_clipboard_buffer();
       const pasteboard = $(PASTEBOARD_SELECTOR);
-      pasteboard.text(decodeURIComponent(escape(clipboard_buffer)));
+      pasteboard.text(clipboard_buffer);
       pasteboard.select();
       this.cdebug(
         "clipboard",
@@ -2058,7 +2052,7 @@ class XpraClient {
     window.addEventListener("cut", (e) => {
       const clipboard_buffer = this.get_clipboard_buffer();
       const pasteboard = $(PASTEBOARD_SELECTOR);
-      pasteboard.text(decodeURIComponent(escape(clipboard_buffer)));
+      pasteboard.text(clipboard_buffer);
       pasteboard.select();
       this.cdebug(
         "clipboard",
@@ -2188,7 +2182,7 @@ class XpraClient {
     navigator.clipboard.readText().then(
       (text) => {
         this.debug("clipboard", "paste event, text=", text);
-        const clipboard_buffer = unescape(encodeURIComponent(text));
+        const clipboard_buffer = encodeURIComponent(text);
         if (clipboard_buffer != this.clipboard_buffer) {
           this.debug("clipboard", "clipboard contents have changed");
           this.clipboard_buffer = clipboard_buffer;
@@ -2965,10 +2959,10 @@ class XpraClient {
         return;
       }
     }
-    const digest = Utilities.s(packet[3]);
-    const server_salt = Utilities.s(packet[1]);
-    const salt_digest = Utilities.s(packet[4]) || "xor";
-    const prompt = (Utilities.s(packet[5]) || "password").replace(
+    const digest = packet[3];
+    const server_salt = Uint8ToString(packet[1]);
+    const salt_digest = packet[4] || "xor";
+    const prompt = (packet[5] || "password").replace(
       /[^\d+,. /:a-z]/gi,
       ""
     );

--- a/html5/js/Protocol.js
+++ b/html5/js/Protocol.js
@@ -397,10 +397,10 @@ class XpraProtocol {
       //decode raw packet string into objects:
       let packet = null;
       try {
-        if (proto_flags == 0x1) {
-          packet = rdecodelegacy(packet_data);
-        } else if (proto_flags == 0x10) {
-          packet = rdecodeplus(packet_data);
+        if (proto_flags == 0x10) {
+          packet = rdecode(packet_data);
+        } else if (proto_flags == 0x1) {
+          throw `rencode legacy mode is not supported, protocol flag: ${proto_flags}`;
         } else {
           throw `invalid packet encoder flags ${proto_flags}`;
         }
@@ -449,7 +449,7 @@ class XpraProtocol {
       let proto_flags = 0x10;
       let bdata = null;
       try {
-        bdata = rencodeplus(packet);
+        bdata = rencode(packet);
       } catch (error) {
         this.error("Error: failed to encode packet:", packet);
         this.error(" with packet encoder", this.packet_encoder);

--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -432,9 +432,9 @@ const Utilities = {
   },
 
   s(v) {
-	if (v===undefined) {
-		return "";
-	}
+    if (v === undefined) {
+      return "";
+    }
     const type = typeof v;
     if (type === "object" && v.constructor === Uint8Array) {
       return Utilities.Uint8ToString(v);
@@ -442,10 +442,10 @@ const Utilities = {
     return v.toString();
   },
 
-  u : function(v){
-	if (v===undefined) {
-		return new Uint8Array(0);
-	}
+  u(v) {
+    if (v === undefined) {
+      return new Uint8Array(0);
+    }
     const type = typeof v;
       if (type === 'object' && v.constructor===Uint8Array) {
         return v;

--- a/html5/js/lib/rencode.js
+++ b/html5/js/lib/rencode.js
@@ -253,14 +253,6 @@ function rencode_none() {
 	return new Uint8Array([RENCODE.CHR_NONE]);
 }
 
-//turn this flag off to use "rencodeplus" when encoding
-//this will send Uint8Array as 'binary'
-//(decoding is always supported since not having it is free)
-let rencode_legacy_mode = false;
-function rencodelegacy(obj) {
-	rencode_legacy_mode = true;
-	return rencode(obj);
-}
 function rencode(obj) {
 	if (obj === null || obj === undefined) {
 		return rencode_none();
@@ -271,15 +263,6 @@ function rencode(obj) {
 			return rencode_dict(obj);
 		}
 		if(obj.constructor===Uint8Array) {
-			if (rencode_legacy_mode) {
-				//legacy rencode cannot handle bytearrays
-				const CHUNK_SZ = 0x8000;
-				const c = [];
-				for (let i=0; i < u8a.length; i+=CHUNK_SZ) {
-					c.push(String.fromCharCode.apply(null, u8a.subarray(i, i+CHUNK_SZ)));
-				}
-				return rencode_string(c.join(""));
-			}
 			return rencode_uint8(obj);
 		}
 		return rencode_list(obj);
@@ -292,10 +275,6 @@ function rencode(obj) {
 		case "boolean":		return rencode_bool(obj?1:0);
 		default:	throw "invalid object type in source: "+type;
 	}
-}
-function rencodeplus(obj) {
-	rencode_legacy_mode = false;
-	return rencode(obj);
 }
 
 function rdecode_string(dec) {
@@ -318,9 +297,7 @@ function rdecode_string(dec) {
 	if (str_len==0) {
 		return "";
 	}
-	if (rencode_legacy_mode) {
-		return Uint8ToString(bytes);
-	}
+
 	return utf8ByteArrayToString(bytes)
 }
 function Uint8ToString(u8a){
@@ -515,15 +492,6 @@ function _rdecode(dec) {
 		throw "no decoder for typecode "+typecode+" at position "+dec.pos;
 	}
 	return decode(dec);
-}
-
-function rdecodelegacy(buf) {
-	rencode_legacy_mode = true;
-	return rdecode(buf);
-}
-function rdecodeplus(buf) {
-	rencode_legacy_mode = false;
-	return rdecode(buf);
 }
 
 function rdecode(buf) {


### PR DESCRIPTION
Fixes the encoding issue when using authentication by using Uint8ToString from `rencode.js` in the `_process_challenge`-function. Also started removing legacy encoding.

We have to test this thoroughly before merging, as it may have unintended effects that I have yet to discover.

Fixes #260