### PR TITLE
More consistent positioning of fullscreen windows

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -3325,7 +3325,7 @@ class XpraClient {
     }
     let client_properties = {};
     if (packet.length >= 8) client_properties = packet[7];
-    if (x == 0 && y == 0 && !metadata["set-initial-position"]) {
+    if (x == 0 && y == 0 && !metadata["set-initial-position"] && !metadata["fullscreen"]) {
       //find a good position for it
       const l = Object.keys(this.id_to_window).length;
       if (l == 0) {

--- a/html5/js/Window.js
+++ b/html5/js/Window.js
@@ -124,6 +124,8 @@ class XpraWindow {
       jQuery(this.div).addClass(`window-${this.windowtype}`);
     }
 
+    const fullscreen = (metadata["fullscreen"]) ?? false;
+
     if (this.client.server_is_desktop || this.client.server_is_shadow) {
       jQuery(this.div).addClass("desktop");
       this.resizable = false;
@@ -131,12 +133,12 @@ class XpraWindow {
       jQuery(this.div).addClass("tray");
     } else if (this.override_redirect) {
       jQuery(this.div).addClass("override-redirect");
-    } else if (
+    } else if (!fullscreen && (
       this.windowtype == "" ||
       this.windowtype == "NORMAL" ||
       this.windowtype == "DIALOG" ||
       this.windowtype == "UTILITY"
-    ) {
+    )) {
       this.resizable = true;
     }
 


### PR DESCRIPTION
Should improve the consistency of window positioning when a window includes the "fullscreen" metadata. 
- Prevents applying an offset position for a fullscreen window positioned at (0, 0)
- Prevents a fullscreen window from being treated as resizable and thus receiving window decorations (and a subsequent topoffset).