### PR TITLE
Bugfix: Prefix the sessionStorage data with pathname

### DIFF
--- a/html5/connect.html
+++ b/html5/connect.html
@@ -617,12 +617,7 @@
 
       function add_prop(prop, value, first) {
         if (Utilities.hasSessionStorage()) {
-          //we're using sessionStorage, no need for URL
-          if (value === null || value === "undefined") {
-            sessionStorage.removeItem(prop);
-          } else {
-            sessionStorage.setItem(prop, value);
-          }
+          Utilities.setSessionStorageValue(prop, value);
           return "";
         }
         if (value === null || value === "undefined") {
@@ -1618,7 +1613,7 @@
         });
         //delete session params:
         try {
-          sessionStorage.clear();
+          Utilities.clearSessionStorage();
         } catch (e) {
           //ignore
         }

--- a/html5/index.html
+++ b/html5/index.html
@@ -793,12 +793,12 @@
         }
 
         try {
-          sessionStorage.removeItem("password");
+          Utilities.setSessionStorageValue("password",null);
         } catch (e) {
           //ignore
         }
         try {
-          sessionStorage.removeItem("token");
+          Utilities.setSessionStorageValue("token",null);
         } catch (e) {
           //ignore
         }
@@ -1033,11 +1033,7 @@
               const has_session_storage = Utilities.hasSessionStorage();
               function add_prop(prop, value) {
                 if (has_session_storage) {
-                  if (value === null || value === "undefined") {
-                    sessionStorage.removeItem(prop);
-                  } else {
-                    sessionStorage.setItem(prop, value);
-                  }
+                  Utilities.setSessionStorageValue(prop, value);
                 } else {
                   if (value === null || value === "undefined") {
                     value = "";

--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -590,9 +590,7 @@ const Utilities = {
     }
     let value = getParameter(property);
     try {
-      if (value === undefined && typeof sessionStorage !== "undefined") {
-        value = sessionStorage.getItem(property);
-      }
+      value = Utilities.getSessionStorageValue(property);
     } catch {
       value = null;
     }
@@ -621,6 +619,34 @@ const Utilities = {
     } catch {
       return false;
     }
+  },
+
+  getSessionStorageValue(property) {
+    const params = JSON.parse(sessionStorage.getItem(Utilities.getSessionStoragePrefix()))
+    if (property in params) {
+      return String(params[property]);
+    }
+    return null;
+  },
+
+  setSessionStorageValue(property, value) {
+    const prefix = Utilities.getSessionStoragePrefix();
+    let params = JSON.parse(sessionStorage.getItem(prefix)) || {}
+    if (value === null || value === "undefined") {
+      delete params[property];
+    } else {
+      params[property] = String(value);
+    }
+    sessionStorage.setItem(prefix, JSON.stringify(params));
+  },
+
+  clearSessionStorage() {
+    sessionStorage.removeItem(Utilities.getSessionStoragePrefix());
+  },
+
+  getSessionStoragePrefix() {
+    const urlPath = new URL(window.location.href).pathname
+    return urlPath.substring(0, urlPath.lastIndexOf("/"));
   },
 
   getConnectionInfo() {


### PR DESCRIPTION
In case of multiple xpra sessions behind a single domain (i.e. reverse proxy), the sessions will overwrite their settings inside the sessionStorage when the user navigates between the sessions within a browser tab. This change will store the sessionStorage data prefixed with the pathname of the xpra session. This fixes #278