### PR TITLE
Bugfix URL parameters not being applied

### DIFF
--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -588,11 +588,14 @@ const Utilities = {
         return window.location.queryStringParams[key];
       };
     }
-    let value = getParameter(property);
+    let value;
     try {
       value = Utilities.getSessionStorageValue(property);
     } catch {
-      value = null;
+      value = undefined;
+    }
+    if (value === undefined) {
+      value = getParameter(property);
     }
     return value;
   },
@@ -626,7 +629,7 @@ const Utilities = {
     if (property in params) {
       return String(params[property]);
     }
-    return null;
+    return undefined;
   },
 
   setSessionStorageValue(property, value) {

--- a/html5/js/Utilities.js
+++ b/html5/js/Utilities.js
@@ -588,15 +588,15 @@ const Utilities = {
         return window.location.queryStringParams[key];
       };
     }
-    let value;
-    try {
-      value = Utilities.getSessionStorageValue(property);
-    } catch {
-      value = undefined;
-    }
+    
+    let value = getParameter(property);
+    
     if (value === undefined) {
-      value = getParameter(property);
+      try {
+        value = Utilities.getSessionStorageValue(property);
+      } catch {}
     }
+    
     return value;
   },
 


### PR DESCRIPTION
URL parameters are not being applied in connect.html or index.html. The root cause is that the `getparam()` function in Utitiles is effectively ignoring url parameters.