### PR TITLE
fix: do not convert u8a to string if it's already a string

### DIFF
--- a/html5/js/lib/rencode.js
+++ b/html5/js/lib/rencode.js
@@ -301,6 +301,10 @@ function rdecode_string(dec) {
 	return utf8ByteArrayToString(bytes)
 }
 function Uint8ToString(u8a){
+	if (typeof u8a == "string") {
+		return u8a;
+	}
+	
 	const CHUNK_SZ = 0x8000;
 	const c = [];
 	for (let i=0; i < u8a.length; i+=CHUNK_SZ) {


### PR DESCRIPTION
Fixes #290 