### PR TITLE
Fix issue with desktops using the --use-display flag being shifted 2.25 px down

### DIFF
--- a/html5/css/client.css
+++ b/html5/css/client.css
@@ -99,6 +99,7 @@ canvas {
 }
 .window.desktop {
   box-shadow: none;
+  top: 0px;
 }
 
 .window-NORMAL {


### PR DESCRIPTION
I could only reproduce this with the --use-display flag. I cannot explain what causes it, as 2.25 is not mentioned anywhere in the codebase. Nonetheless, this is a small fix to a minor issue that is just a little bit annoying.