### PR TITLE
Fix session info box not being big enough

### DIFF
--- a/html5/css/client.css
+++ b/html5/css/client.css
@@ -381,7 +381,7 @@ div.windowinfocus div.windowhead {
   position: fixed;
   margin: auto;
   width: 640px;
-  height: 280px;
+  height: fit-content;
   top: 50%;
   left: 50%;
   margin-left: -320px;
@@ -404,6 +404,7 @@ div.windowinfocus div.windowhead {
 
 table#sessiondata {
   width: 90%;
+  margin: auto;
 }
 table#sessiondata th {
   text-align: left;


### PR DESCRIPTION
The session info box is not big enough to fit the text. This fixes that.