### PR TITLE
fix: Don't use the default font for the connecting UI

### DIFF
--- a/html5/css/client.css
+++ b/html5/css/client.css
@@ -43,6 +43,7 @@ div#disconnect_form {
 }
 .overlay {
   background-color: black;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   position: fixed;
   top: 0;
   right: 0;
@@ -124,7 +125,7 @@ canvas {
   background-color: transparent;
 }
 .windowtitle {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   display: inline-block;
   float: left;
   position: absolute;


### PR DESCRIPTION
Previously, the connecting UI used the browser's default font (which is often an ugly serif one). Change it to the font used everywhere else and replace one font usage to make them consistent everywhere.