### PR TITLE
chore: Remove some legacy html parts

### DIFF
--- a/html5/connect.html
+++ b/html5/connect.html
@@ -6,11 +6,8 @@
 	Copyright (c) 2014 Joshua Higgins <josh@kxes.net>
 	Licensed under MPL 2.0
 	-->
-
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <!-- Custom styles for this template -->
     <link href="css/connect.css" rel="stylesheet" />
     <title>Xpra HTML5 Client</title>

--- a/html5/index.html
+++ b/html5/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html lang="en">
   <head>
     <!--
             Copyright (c) 2013-2022 Antoine Martin <antoine@xpra.org>


### PR DESCRIPTION
X-UA-Compatible is no longer necessary. The XHTML header is incorrect.