### PR TITLE
Fix desktop sessions not setting cursors correctly

### DIFF
--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -1653,6 +1653,7 @@ class XpraClient {
     const buttons = [];
     const coords = [x, y];
     let wid = 0;
+    if (this.server_is_desktop) wid = 1;
     if (win) {
       wid = win.wid;
       // add relative coordinates:


### PR DESCRIPTION
In desktop sessions, cursors only set when clicking on the screen, unlike seamless sessions where they work as intended and always are on screen. This fixes that.