### PR TITLE
fix: add null check for navigator.keyboard in toggle_fullscreen()

### DIFF
--- a/html5/index.html
+++ b/html5/index.html
@@ -1307,14 +1307,17 @@
             "F10",
             "F11",
           ];
-          navigator.keyboard
-            .lock(keys)
-            .then(() => {
-              console.log("keyboard lock success");
-            })
-            .catch((e) => {
-              console.log("keyboard lock failed: ", e);
-            });
+          // Keyboard Lock API not supported in all browsers/contexts
+          if (navigator.keyboard && navigator.keyboard.lock) {
+            navigator.keyboard
+              .lock(keys)
+              .then(() => {
+                console.log("keyboard lock success");
+              })
+              .catch((e) => {
+                console.log("keyboard lock failed: ", e);
+              });
+          }
 
           $("#fullscreen").attr("src", "./icons/unfullscreen.png");
           elem.title = "Exit Fullscreen";


### PR DESCRIPTION
## Summary

Add a null check for `navigator.keyboard` before calling `.lock()` to prevent crashes in browsers where the Keyboard Lock API is not available.

## Problem

The current `toggle_fullscreen()` function crashes with:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'lock')
    at toggle_fullscreen ((index):1311:14)
```

This occurs because `navigator.keyboard` is `undefined` in some browsers/contexts (e.g., Microsoft Edge 142.0.3595.94 on Windows).

## Console Debug Logs

```
toggle_fullscreen() fullscreenEnabled= true
toggle_fullscreen() elem= <a href="#" id="fullscreen_button" title="Fullscreen" data-icon="fullscreen">…</a>
toggle_fullscreen() is_fullscreen= false
Uncaught TypeError: Cannot read properties of undefined (reading 'lock')
```

The fullscreen itself activates successfully (as seen by `fullscreenchange` event), but then crashes on the keyboard lock call.

## Solution

Wrap the `navigator.keyboard.lock()` call with a null check:

```diff
           ];
-          navigator.keyboard
-            .lock(keys)
+          // Keyboard Lock API not supported in all browsers/contexts
+          if (navigator.keyboard && navigator.keyboard.lock) {
+            navigator.keyboard
+              .lock(keys)
+              .then(() => {
+                console.log("keyboard lock success");
+              })
+              .catch((e) => {
+                console.log("keyboard lock failed: ", e);
+              });
+          }
```

## References

- [Keyboard Lock API - MDN](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/lock) - Documents browser compatibility
- Issue #402 - Original fullscreen button bug report

## Test Environment

- Browser: Microsoft Edge 142.0.3595.94 (64-bit) on Windows
- Server: xpra 6.3.6, xpra-html5 18.1, Ubuntu 24.04 LTS

## Test Results

| Before Fix | After Fix |
|------------|-----------|
| Fullscreen activates then crashes | Fullscreen works without errors |
| `TypeError: Cannot read properties of undefined` | No errors in console |