### PR TITLE
add middle mouse button emulation

### DIFF
--- a/html5/connect.html
+++ b/html5/connect.html
@@ -319,6 +319,16 @@
                   <span>Reverse horizontal scrolling</span>
                 </li>
                 <li class="list-group-item">
+                  <span>Emulate middle click using modifier + left click</span>
+                  <select id="middle_emulation_modifier">
+                    <option value="">None</option>
+                    <option value="control">Control</option>
+                    <option value="meta">Meta / Command</option>
+                    <option value="alt">Alt / Option</option>
+                    <option value="shift">Shift</option>
+                  </select>
+                </li>
+                <li class="list-group-item">
                   <input type="checkbox" id="floating_menu" />
                   <span>Floating Menu</span>,
                   <input type="checkbox" id="autohide" />
@@ -390,6 +400,7 @@
         "override_width",
         "encryption",
         "scroll_reverse_y",
+        "middle_emulation_modifier",
         "vrefresh",
         "clipboard_preferred_format",
       ];
@@ -1530,6 +1541,8 @@
         //scroll_reverse_y has 3 options: Yes, No, Auto
         const scroll_reverse_y = getboolparam("scroll_reverse_y", "auto");
         document.getElementById("scroll_reverse_y").value = scroll_reverse_y;
+        const middle_emulation_modifier = getstrparam("middle_emulation_modifier") || "";
+        document.getElementById("middle_emulation_modifier").value = middle_emulation_modifier;
 
         function toggle_mediasource_video() {
           $("#mediasource_video").prop("disabled", !video.checked);

--- a/html5/index.html
+++ b/html5/index.html
@@ -692,6 +692,7 @@
         const swap_keys = getboolparam("swap_keys", Utilities.isMacOS());
         const scroll_reverse_x = getboolparam("scroll_reverse_x", false);
         const scroll_reverse_y = getboolautoparam("scroll_reverse_y", null);
+        const middle_emulation_modifier = getstrparam("middle_emulation_modifier") || "";
         const floating_menu = getboolparam("floating_menu", true);
         const toolbar_position = getstrparam("toolbar_position");
         const autohide = getboolparam("autohide", false);
@@ -796,6 +797,7 @@
         client.steal = steal;
         client.reconnect = reconnect;
         client.swap_keys = swap_keys;
+        client.middle_emulation_modifier = middle_emulation_modifier;
         client.on_connection_progress = connection_progress;
         client.scroll_reverse_x = scroll_reverse_x;
         client.scroll_reverse_y = scroll_reverse_y;
@@ -966,6 +968,7 @@
               swap_keys: swap_keys,
               scroll_reverse_x: scroll_reverse_x,
               scroll_reverse_y: scroll_reverse_y,
+              middle_emulation_modifier: middle_emulation_modifier,
               reconnect: reconnect,
               action: action,
               display: display,

--- a/html5/js/Client.js
+++ b/html5/js/Client.js
@@ -288,6 +288,8 @@ class XpraClient {
     this.mouse_grabbed = false;
     this.scroll_reverse_x = false;
     this.scroll_reverse_y = "auto";
+    this.middle_emulation_modifier = default_settings["middle_emulation_modifier"] || "";
+    this.middle_emulation_button = 2;
     // clipboard
     this.clipboard_direction = default_settings["clipboard_direction"] || "both";
     this.clipboard_datatype = null;
@@ -1820,6 +1822,22 @@ class XpraClient {
     }
 
     let button = mouse.button;
+    const emulate_mod = (this.middle_emulation_modifier || "").toLowerCase();
+    const emulate_with = {
+      "control": e.ctrlKey,
+      "meta": e.metaKey,
+      "alt": e.altKey,
+      "shift": e.shiftKey,
+    };
+    const modifier_active = emulate_mod && emulate_with[emulate_mod];
+    if (modifier_active && button === 1) {
+      button = this.middle_emulation_button || 2;
+      const translated_mod = this.translate_modifiers([emulate_mod])[0];
+      const mod_index = modifiers.indexOf(translated_mod);
+      if (mod_index >= 0) {
+        modifiers.splice(mod_index, 1);
+      }
+    }
     const lbe = this.last_button_event;
     if (lbe[0] === button && lbe[1] === pressed && lbe[2] === x && lbe[3] === y) {
       //duplicate!


### PR DESCRIPTION
This adds modifier key + left click emulation of middle mouse clicks to the HTML5 client.

Closes https://github.com/Xpra-org/xpra/issues/4608.