### PR TITLE
fix window dragging: do not return from jQuery canvas mouse handlers

### DIFF
--- a/html5/js/Window.js
+++ b/html5/js/Window.js
@@ -391,13 +391,13 @@ class XpraWindow {
   register_canvas_mouse_events(canvas) {
     // Hook up the events we want to receive:
     jQuery(canvas).mousedown((e) => {
-      return this.mouse_down_cb(e, this);
+      this.mouse_down_cb(e, this);
     });
     jQuery(canvas).mouseup((e) => {
-      return this.mouse_up_cb(e, this);
+      this.mouse_up_cb(e, this);
     });
     jQuery(canvas).mousemove((e) => {
-      return this.mouse_move_cb(e, this);
+      this.mouse_move_cb(e, this);
     });
   }
 


### PR DESCRIPTION
Commit 50236a8 introduced a regression where windows can no longer be dragged.

In `register_canvas_mouse_events()`, the mouse callbacks (`on_mousedown`,
`on_mouseup`, `on_mousemove`) return `!win`. When called from a canvas event
handler, `win` is an `XpraWindow` object (truthy), so the return value is
`false`.

Returning `false` from a jQuery event handler is equivalent to calling both
`event.stopPropagation()` and `event.preventDefault()`. This prevents jQuery
UI draggable from receiving the mouse events it needs, making windows
impossible to move.

The fix is to not forward the callbacks' return values to jQuery.